### PR TITLE
Enable verbosity control of PTBTokenizer

### DIFF
--- a/language_evaluation/__init__.py
+++ b/language_evaluation/__init__.py
@@ -80,9 +80,11 @@ class CocoEvaluator(Evaluator):
     def __init__(self,
                  coco_types=["BLEU", "METEOR", "ROUGE_L", "CIDEr", "SPICE"],
                  tokenization_fn=None,
+                 verbose=True,
                  unk_token='_UNK'):
         self.coco_types = coco_types
         self._tokenization_fn = tokenization_fn
+        self.verbose = verbose
         self._unk_token = unk_token
 
     def run_evaluation(self, predicts, answers):
@@ -106,7 +108,7 @@ class CocoEvaluator(Evaluator):
         with contextlib.redirect_stdout(None):
             coco = COCO(ann)
             coco_res = coco.loadRes(coco_res)
-            coco_eval = COCOEvalCap(coco, coco_res, self.coco_types, self._tokenization_fn)
+            coco_eval = COCOEvalCap(coco, coco_res, self.coco_types, self._tokenization_fn, verbose=self.verbose)
             coco_eval.evaluate()
 
         return coco_eval.eval

--- a/language_evaluation/coco_caption_py3/pycocoevalcap/eval.py
+++ b/language_evaluation/coco_caption_py3/pycocoevalcap/eval.py
@@ -15,7 +15,7 @@ _COCO_TYPE_TO_METRIC = {
 }
 
 class COCOEvalCap:
-    def __init__(self, coco, cocoRes, cocoTypes, tokenization_fn=None):
+    def __init__(self, coco, cocoRes, cocoTypes, tokenization_fn=None, verbose=True):
         self.evalImgs = []
         self.eval = {}
         self.imgToEval = {}
@@ -24,6 +24,7 @@ class COCOEvalCap:
         self.params = {'image_id': coco.getImgIds()}
         self.cocoTypes = cocoTypes
         self.tokenization_fn = tokenization_fn
+        self.verbose = verbose
 
     def evaluate(self):
         imgIds = self.params['image_id']
@@ -38,7 +39,7 @@ class COCOEvalCap:
         # Set up scorers
         # =================================================
         print('tokenization...')
-        tokenizer = PTBTokenizer(self.tokenization_fn)
+        tokenizer = PTBTokenizer(self.tokenization_fn, verbose=self.verbose)
         gts = tokenizer.tokenize(gts)
         res = tokenizer.tokenize(res)
 

--- a/language_evaluation/coco_caption_py3/pycocoevalcap/tokenizer/ptbtokenizer.py
+++ b/language_evaluation/coco_caption_py3/pycocoevalcap/tokenizer/ptbtokenizer.py
@@ -54,7 +54,7 @@ class PTBTokenizer:
             # tokenize sentence
             # ======================================================
             cmd.append(os.path.basename(tmp_file.name))
-            if verbose:
+            if self.verbose:
                 p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
                     stdout=subprocess.PIPE)
             else:

--- a/language_evaluation/coco_caption_py3/pycocoevalcap/tokenizer/ptbtokenizer.py
+++ b/language_evaluation/coco_caption_py3/pycocoevalcap/tokenizer/ptbtokenizer.py
@@ -23,8 +23,9 @@ PUNCTUATIONS = ["''", "'", "``", "`", "-LRB-", "-RRB-", "-LCB-", "-RCB-", \
 
 class PTBTokenizer:
     """Python wrapper of Stanford PTBTokenizer"""
-    def __init__(self, tokenization_fn=None):
+    def __init__(self, tokenization_fn=None, verbose=True):
         self.tokenization_fn = tokenization_fn
+        self.verbose = verbose
 
     def tokenize(self, captions_for_image):
         cmd = ['java', '-cp', STANFORD_CORENLP_3_4_1_JAR, \
@@ -53,8 +54,12 @@ class PTBTokenizer:
             # tokenize sentence
             # ======================================================
             cmd.append(os.path.basename(tmp_file.name))
-            p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
+            if verbose:
+                p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
                     stdout=subprocess.PIPE)
+            else:
+                p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
+                    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
             token_lines = p_tokenizer.communicate(input=sentences.rstrip())[0]
             token_lines = token_lines.decode()
             lines = token_lines.split('\n')


### PR DESCRIPTION
PTBTokenizer logs tokenization details by default (ex. `PTBTokenizer tokenized 2 tokens at 33.87 tokens per second`).
This becomes noisy when you have run tokenization iteratively.
I redirect stderr to `subprocess.DEVNULL` to suppress this.